### PR TITLE
Cleanly separate Circom1 and Circom2 traits

### DIFF
--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -7,26 +7,25 @@ pub struct Wasm(Instance);
 pub trait CircomBase {
     fn init(&self, sanity_check: bool) -> Result<()>;
     fn func(&self, name: &str) -> &Function;
-    fn get_ptr_witness_buffer(&self) -> Result<u32>;
-    fn get_ptr_witness(&self, w: u32) -> Result<u32>;
+    //fn get_ptr_witness(&self, w: u32) -> Result<u32>;
     fn get_n_vars(&self) -> Result<u32>;
-    fn get_signal_offset32(
-        &self,
-        p_sig_offset: u32,
-        component: u32,
-        hash_msb: u32,
-        hash_lsb: u32,
-    ) -> Result<()>;
-    fn set_signal(&self, c_idx: u32, component: u32, signal: u32, p_val: u32) -> Result<()>;
+    //fn get_signal_offset32(
+    //    &self,
+    //    p_sig_offset: u32,
+    //    component: u32,
+    //    hash_msb: u32,
+    //    hash_lsb: u32,
+    //) -> Result<()>;
+    //fn set_signal(&self, c_idx: u32, component: u32, signal: u32, p_val: u32) -> Result<()>;
     fn get_u32(&self, name: &str) -> Result<u32>;
     // Only exists natively in Circom2, hardcoded for Circom
     fn get_version(&self) -> Result<u32>;
 }
 
-pub trait Circom {
-    fn get_fr_len(&self) -> Result<u32>;
-    fn get_ptr_raw_prime(&self) -> Result<u32>;
-}
+// pub trait Circom {
+//     fn get_fr_len(&self) -> Result<u32>;
+//     fn get_ptr_raw_prime(&self) -> Result<u32>;
+// }
 
 pub trait Circom2 {
     fn get_field_num_len32(&self) -> Result<u32>;
@@ -38,15 +37,15 @@ pub trait Circom2 {
     fn get_witness_size(&self) -> Result<u32>;
 }
 
-impl Circom for Wasm {
-    fn get_fr_len(&self) -> Result<u32> {
-        self.get_u32("getFrLen")
-    }
-
-    fn get_ptr_raw_prime(&self) -> Result<u32> {
-        self.get_u32("getPRawPrime")
-    }
-}
+// impl Circom for Wasm {
+//     fn get_fr_len(&self) -> Result<u32> {
+//         self.get_u32("getFrLen")
+//     }
+//
+//     fn get_ptr_raw_prime(&self) -> Result<u32> {
+//         self.get_u32("getPRawPrime")
+//     }
+// }
 
 #[cfg(feature = "circom-2")]
 impl Circom2 for Wasm {
@@ -96,45 +95,41 @@ impl CircomBase for Wasm {
         Ok(())
     }
 
-    fn get_ptr_witness_buffer(&self) -> Result<u32> {
-        self.get_u32("getWitnessBuffer")
-    }
+    //fn get_ptr_witness(&self, w: u32) -> Result<u32> {
+    //    let func = self.func("getPWitness");
+    //    let res = func.call(&[w.into()])?;
 
-    fn get_ptr_witness(&self, w: u32) -> Result<u32> {
-        let func = self.func("getPWitness");
-        let res = func.call(&[w.into()])?;
-
-        Ok(res[0].unwrap_i32() as u32)
-    }
+    //    Ok(res[0].unwrap_i32() as u32)
+    //}
 
     fn get_n_vars(&self) -> Result<u32> {
         self.get_u32("getNVars")
     }
 
-    fn get_signal_offset32(
-        &self,
-        p_sig_offset: u32,
-        component: u32,
-        hash_msb: u32,
-        hash_lsb: u32,
-    ) -> Result<()> {
-        let func = self.func("getSignalOffset32");
-        func.call(&[
-            p_sig_offset.into(),
-            component.into(),
-            hash_msb.into(),
-            hash_lsb.into(),
-        ])?;
+    //fn get_signal_offset32(
+    //    &self,
+    //    p_sig_offset: u32,
+    //    component: u32,
+    //    hash_msb: u32,
+    //    hash_lsb: u32,
+    //) -> Result<()> {
+    //    let func = self.func("getSignalOffset32");
+    //    func.call(&[
+    //        p_sig_offset.into(),
+    //        component.into(),
+    //        hash_msb.into(),
+    //        hash_lsb.into(),
+    //    ])?;
 
-        Ok(())
-    }
+    //    Ok(())
+    //}
 
-    fn set_signal(&self, c_idx: u32, component: u32, signal: u32, p_val: u32) -> Result<()> {
-        let func = self.func("setSignal");
-        func.call(&[c_idx.into(), component.into(), signal.into(), p_val.into()])?;
+    //fn set_signal(&self, c_idx: u32, component: u32, signal: u32, p_val: u32) -> Result<()> {
+    //    let func = self.func("setSignal");
+    //    func.call(&[c_idx.into(), component.into(), signal.into(), p_val.into()])?;
 
-        Ok(())
-    }
+    //    Ok(())
+    //}
 
     // Default to version 1 if it isn't explicitly defined
     fn get_version(&self) -> Result<u32> {

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -13,7 +13,7 @@ pub trait CircomBase {
     fn get_version(&self) -> Result<u32>;
 }
 
-pub trait Circom {
+pub trait Circom1 {
     fn get_ptr_witness(&self, w: u32) -> Result<u32>;
     fn get_fr_len(&self) -> Result<u32>;
     fn get_signal_offset32(
@@ -37,7 +37,7 @@ pub trait Circom2 {
     fn get_witness_size(&self) -> Result<u32>;
 }
 
-impl Circom for Wasm {
+impl Circom1 for Wasm {
     fn get_fr_len(&self) -> Result<u32> {
         self.get_u32("getFrLen")
     }

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -10,7 +10,7 @@ pub(super) use circom::{CircomBase, Wasm};
 #[cfg(feature = "circom-2")]
 pub(super) use circom::Circom2;
 
-pub(super) use circom::Circom;
+pub(super) use circom::Circom1;
 
 use fnv::FnvHasher;
 use std::hash::Hasher;

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -10,7 +10,7 @@ pub(super) use circom::{CircomBase, Wasm};
 #[cfg(feature = "circom-2")]
 pub(super) use circom::Circom2;
 
-pub(super) use circom::Circom;
+// pub(super) use circom::Circom;
 
 use fnv::FnvHasher;
 use std::hash::Hasher;

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -10,7 +10,7 @@ pub(super) use circom::{CircomBase, Wasm};
 #[cfg(feature = "circom-2")]
 pub(super) use circom::Circom2;
 
-// pub(super) use circom::Circom;
+pub(super) use circom::Circom;
 
 use fnv::FnvHasher;
 use std::hash::Hasher;

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -8,7 +8,7 @@ use wasmer::{imports, Function, Instance, Memory, MemoryType, Module, RuntimeErr
 #[cfg(feature = "circom-2")]
 use num::ToPrimitive;
 
-use super::Circom;
+use super::Circom1;
 #[cfg(feature = "circom-2")]
 use super::Circom2;
 

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -15,7 +15,7 @@ use super::Circom2;
 #[derive(Clone, Debug)]
 pub struct WitnessCalculator {
     pub instance: Wasm,
-    pub memory: SafeMemory,
+    pub memory: Option<SafeMemory>,
     pub n64: u32,
     pub circom_version: u32,
 }
@@ -91,9 +91,8 @@ impl WitnessCalculator {
 
         // Circom 2 feature flag with version 2
         #[cfg(feature = "circom-2")]
-        fn new_circom2(instance: Wasm, memory: Memory, version: u32) -> Result<WitnessCalculator> {
+        fn new_circom2(instance: Wasm, version: u32) -> Result<WitnessCalculator> {
             let n32 = instance.get_field_num_len32()?;
-            let mut safe_memory = SafeMemory::new(memory, n32 as usize, BigInt::zero());
             instance.get_raw_prime()?;
             let mut arr = vec![0; n32 as usize];
             for i in 0..n32 {
@@ -103,11 +102,10 @@ impl WitnessCalculator {
             let prime = from_array32(arr);
 
             let n64 = ((prime.bits() - 1) / 64 + 1) as u32;
-            safe_memory.prime = prime;
 
             Ok(WitnessCalculator {
                 instance,
-                memory: safe_memory,
+                memory: None,
                 n64,
                 circom_version: version,
             })
@@ -125,7 +123,7 @@ impl WitnessCalculator {
 
             Ok(WitnessCalculator {
                 instance,
-                memory: safe_memory,
+                memory: Some(safe_memory),
                 n64,
                 circom_version: version,
             })
@@ -141,7 +139,7 @@ impl WitnessCalculator {
         cfg_if::cfg_if! {
             if #[cfg(feature = "circom-2")] {
                 match version {
-                    2 => new_circom2(instance, memory, version),
+                    2 => new_circom2(instance, version),
                     1 => new_circom1(instance, memory, version),
 
                     _ => panic!("Unknown Circom version")
@@ -181,9 +179,9 @@ impl WitnessCalculator {
     ) -> Result<Vec<BigInt>> {
         self.instance.init(sanity_check)?;
 
-        let old_mem_free_pos = self.memory.free_pos();
-        let p_sig_offset = self.memory.alloc_u32();
-        let p_fr = self.memory.alloc_fr();
+        let old_mem_free_pos = self.memory.as_ref().unwrap().free_pos();
+        let p_sig_offset = self.memory.as_mut().unwrap().alloc_u32();
+        let p_fr = self.memory.as_mut().unwrap().alloc_fr();
 
         // allocate the inputs
         for (name, values) in inputs.into_iter() {
@@ -192,10 +190,17 @@ impl WitnessCalculator {
             self.instance
                 .get_signal_offset32(p_sig_offset, 0, msb, lsb)?;
 
-            let sig_offset = self.memory.read_u32(p_sig_offset as usize) as usize;
+            let sig_offset = self
+                .memory
+                .as_ref()
+                .unwrap()
+                .read_u32(p_sig_offset as usize) as usize;
 
             for (i, value) in values.into_iter().enumerate() {
-                self.memory.write_fr(p_fr as usize, &value)?;
+                self.memory
+                    .as_mut()
+                    .unwrap()
+                    .write_fr(p_fr as usize, &value)?;
                 self.instance
                     .set_signal(0, 0, (sig_offset + i) as u32, p_fr)?;
             }
@@ -206,11 +211,11 @@ impl WitnessCalculator {
         let n_vars = self.instance.get_n_vars()?;
         for i in 0..n_vars {
             let ptr = self.instance.get_ptr_witness(i)? as usize;
-            let el = self.memory.read_fr(ptr)?;
+            let el = self.memory.as_ref().unwrap().read_fr(ptr)?;
             w.push(el);
         }
 
-        self.memory.set_free_pos(old_mem_free_pos);
+        self.memory.as_mut().unwrap().set_free_pos(old_mem_free_pos);
 
         Ok(w)
     }
@@ -449,10 +454,6 @@ mod tests {
 
     fn run_test(case: TestCase) {
         let mut wtns = WitnessCalculator::new(case.circuit_path).unwrap();
-        assert_eq!(
-            wtns.memory.prime.to_str_radix(16),
-            "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000001".to_lowercase()
-        );
         assert_eq!({ wtns.instance.get_n_vars().unwrap() }, case.n_vars);
         assert_eq!({ wtns.n64 }, case.n64);
 

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -2,7 +2,6 @@ use super::{fnv, CircomBase, SafeMemory, Wasm};
 use color_eyre::Result;
 use num_bigint::BigInt;
 use num_traits::Zero;
-// use std::cell::Cell;
 use wasmer::{imports, Function, Instance, Memory, MemoryType, Module, RuntimeError, Store};
 
 #[cfg(feature = "circom-2")]
@@ -18,6 +17,7 @@ pub struct WitnessCalculator {
     pub memory: Option<SafeMemory>,
     pub n64: u32,
     pub circom_version: u32,
+    pub prime: BigInt,
 }
 
 // Error type to signal end of execution.
@@ -108,6 +108,7 @@ impl WitnessCalculator {
                 memory: None,
                 n64,
                 circom_version: version,
+                prime,
             })
         }
 
@@ -119,13 +120,14 @@ impl WitnessCalculator {
             let prime = safe_memory.read_big(ptr as usize, n32 as usize)?;
 
             let n64 = ((prime.bits() - 1) / 64 + 1) as u32;
-            safe_memory.prime = prime;
+            safe_memory.prime = prime.clone();
 
             Ok(WitnessCalculator {
                 instance,
                 memory: Some(safe_memory),
                 n64,
                 circom_version: version,
+                prime,
             })
         }
 
@@ -141,12 +143,10 @@ impl WitnessCalculator {
                 match version {
                     2 => new_circom2(instance, version),
                     1 => new_circom1(instance, memory, version),
-
                     _ => panic!("Unknown Circom version")
                 }
             } else {
                 new_circom1(instance, memory, version)
-                _ => panic!("Unknown Circom version")
             }
         }
     }
@@ -454,6 +454,10 @@ mod tests {
 
     fn run_test(case: TestCase) {
         let mut wtns = WitnessCalculator::new(case.circuit_path).unwrap();
+        assert_eq!(
+            wtns.prime.to_str_radix(16),
+            "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000001".to_lowercase()
+        );
         assert_eq!({ wtns.instance.get_n_vars().unwrap() }, case.n_vars);
         assert_eq!({ wtns.n64 }, case.n64);
 

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -2,16 +2,15 @@ use super::{fnv, CircomBase, SafeMemory, Wasm};
 use color_eyre::Result;
 use num_bigint::BigInt;
 use num_traits::Zero;
-use std::cell::Cell;
+// use std::cell::Cell;
 use wasmer::{imports, Function, Instance, Memory, MemoryType, Module, RuntimeError, Store};
 
 #[cfg(feature = "circom-2")]
 use num::ToPrimitive;
 
+// use super::Circom;
 #[cfg(feature = "circom-2")]
 use super::Circom2;
-
-use super::Circom;
 
 #[derive(Clone, Debug)]
 pub struct WitnessCalculator {
@@ -114,23 +113,23 @@ impl WitnessCalculator {
             })
         }
 
-        fn new_circom1(instance: Wasm, memory: Memory, version: u32) -> Result<WitnessCalculator> {
-            // Fallback to Circom 1 behavior
-            let n32 = (instance.get_fr_len()? >> 2) - 2;
-            let mut safe_memory = SafeMemory::new(memory, n32 as usize, BigInt::zero());
-            let ptr = instance.get_ptr_raw_prime()?;
-            let prime = safe_memory.read_big(ptr as usize, n32 as usize)?;
+        //fn new_circom1(instance: Wasm, memory: Memory, version: u32) -> Result<WitnessCalculator> {
+        //    // Fallback to Circom 1 behavior
+        //    let n32 = (instance.get_fr_len()? >> 2) - 2;
+        //    let mut safe_memory = SafeMemory::new(memory, n32 as usize, BigInt::zero());
+        //    let ptr = instance.get_ptr_raw_prime()?;
+        //    let prime = safe_memory.read_big(ptr as usize, n32 as usize)?;
 
-            let n64 = ((prime.bits() - 1) / 64 + 1) as u32;
-            safe_memory.prime = prime;
+        //    let n64 = ((prime.bits() - 1) / 64 + 1) as u32;
+        //    safe_memory.prime = prime;
 
-            Ok(WitnessCalculator {
-                instance,
-                memory: safe_memory,
-                n64,
-                circom_version: version,
-            })
-        }
+        //    Ok(WitnessCalculator {
+        //        instance,
+        //        memory: safe_memory,
+        //        n64,
+        //        circom_version: version,
+        //    })
+        //}
 
         // Three possibilities:
         // a) Circom 2 feature flag enabled, WASM runtime version 2
@@ -143,11 +142,13 @@ impl WitnessCalculator {
             if #[cfg(feature = "circom-2")] {
                 match version {
                     2 => new_circom2(instance, memory, version),
-                    1 => new_circom1(instance, memory, version),
+                    //1 => new_circom1(instance, memory, version),
+
                     _ => panic!("Unknown Circom version")
                 }
             } else {
-                new_circom1(instance, memory, version)
+                //new_circom1(instance, memory, version)
+                _ => panic!("Unknown Circom version")
             }
         }
     }
@@ -163,56 +164,57 @@ impl WitnessCalculator {
             if #[cfg(feature = "circom-2")] {
                 match self.circom_version {
                     2 => self.calculate_witness_circom2(inputs, sanity_check),
-                    1 => self.calculate_witness_circom1(inputs, sanity_check),
+                    //1 => self.calculate_witness_circom1(inputs, sanity_check),
                     _ => panic!("Unknown Circom version")
                 }
             } else {
-                self.calculate_witness_circom1(inputs, sanity_check)
+                //self.calculate_witness_circom1(inputs, sanity_check)
+                _ => panic!("Unknown Circom version")
             }
         }
     }
 
     // Circom 1 default behavior
-    fn calculate_witness_circom1<I: IntoIterator<Item = (String, Vec<BigInt>)>>(
-        &mut self,
-        inputs: I,
-        sanity_check: bool,
-    ) -> Result<Vec<BigInt>> {
-        self.instance.init(sanity_check)?;
+    //fn calculate_witness_circom1<I: IntoIterator<Item = (String, Vec<BigInt>)>>(
+    //    &mut self,
+    //    inputs: I,
+    //    sanity_check: bool,
+    //) -> Result<Vec<BigInt>> {
+    //    self.instance.init(sanity_check)?;
 
-        let old_mem_free_pos = self.memory.free_pos();
-        let p_sig_offset = self.memory.alloc_u32();
-        let p_fr = self.memory.alloc_fr();
+    //    let old_mem_free_pos = self.memory.free_pos();
+    //    let p_sig_offset = self.memory.alloc_u32();
+    //    let p_fr = self.memory.alloc_fr();
 
-        // allocate the inputs
-        for (name, values) in inputs.into_iter() {
-            let (msb, lsb) = fnv(&name);
+    //    // allocate the inputs
+    //    for (name, values) in inputs.into_iter() {
+    //        let (msb, lsb) = fnv(&name);
 
-            self.instance
-                .get_signal_offset32(p_sig_offset, 0, msb, lsb)?;
+    //        self.instance
+    //            .get_signal_offset32(p_sig_offset, 0, msb, lsb)?;
 
-            let sig_offset = self.memory.read_u32(p_sig_offset as usize) as usize;
+    //        let sig_offset = self.memory.read_u32(p_sig_offset as usize) as usize;
 
-            for (i, value) in values.into_iter().enumerate() {
-                self.memory.write_fr(p_fr as usize, &value)?;
-                self.instance
-                    .set_signal(0, 0, (sig_offset + i) as u32, p_fr)?;
-            }
-        }
+    //        for (i, value) in values.into_iter().enumerate() {
+    //            self.memory.write_fr(p_fr as usize, &value)?;
+    //            self.instance
+    //                .set_signal(0, 0, (sig_offset + i) as u32, p_fr)?;
+    //        }
+    //    }
 
-        let mut w = Vec::new();
+    //    let mut w = Vec::new();
 
-        let n_vars = self.instance.get_n_vars()?;
-        for i in 0..n_vars {
-            let ptr = self.instance.get_ptr_witness(i)? as usize;
-            let el = self.memory.read_fr(ptr)?;
-            w.push(el);
-        }
+    //    let n_vars = self.instance.get_n_vars()?;
+    //    for i in 0..n_vars {
+    //        let ptr = self.instance.get_ptr_witness(i)? as usize;
+    //        let el = self.memory.read_fr(ptr)?;
+    //        w.push(el);
+    //    }
 
-        self.memory.set_free_pos(old_mem_free_pos);
+    //    self.memory.set_free_pos(old_mem_free_pos);
 
-        Ok(w)
-    }
+    //    Ok(w)
+    //}
 
     // Circom 2 feature flag with version 2
     #[cfg(feature = "circom-2")]
@@ -282,20 +284,6 @@ impl WitnessCalculator {
             .collect::<Vec<_>>();
 
         Ok(witness)
-    }
-
-    pub fn get_witness_buffer(&self) -> Result<Vec<u8>> {
-        let ptr = self.instance.get_ptr_witness_buffer()? as usize;
-
-        let view = self.memory.memory.view::<u8>();
-
-        let len = self.instance.get_n_vars()? * self.n64 * 8;
-        let arr = view[ptr..ptr + len as usize]
-            .iter()
-            .map(Cell::get)
-            .collect::<Vec<_>>();
-
-        Ok(arr)
     }
 }
 


### PR DESCRIPTION
I was working on upgrading the libraries here to use more recent versions of `wasmer` -- I have tests passing for the most recent versions `4.2.*`. In the process I noticed that the separation between `CircomBase` `Circom` and `Circom2` traits wasn't as clean as it could be, and in fact this was affecting the project I was working on. These should all be non-breaking changes:

- Rename `Circom` trait to `Circom1` for consistency and to make it easier to explain this work.
- When creating a `WitnessCalculator` object, we don't use the `SafeMemory` object for the `Circom2` trait methods and iiuc it won't even work in this case. This field should be optional and take a value of `None` for the circom2 case.
- Move `ptr` based methods from `CircomBase` to `Circom1`, as they are not useful in the `Circom2` case.
- move shared functions `get_version` and `get_u32` to `CircomBase`
- remove the unused function `get_witness_buffer`