### PR TITLE
Improve R1CS File Loading Speed with BufReader

### DIFF
--- a/src/circom/builder.rs
+++ b/src/circom/builder.rs
@@ -1,5 +1,5 @@
 use ark_ec::pairing::Pairing;
-use std::{fs::File, path::Path};
+use std::{fs::File, io::BufReader, path::Path};
 
 use super::{CircomCircuit, R1CS};
 
@@ -26,7 +26,7 @@ pub struct CircomConfig<E: Pairing> {
 impl<E: Pairing> CircomConfig<E> {
     pub fn new(wtns: impl AsRef<Path>, r1cs: impl AsRef<Path>) -> Result<Self> {
         let wtns = WitnessCalculator::new(wtns).unwrap();
-        let reader = File::open(r1cs)?;
+        let reader = BufReader::new(File::open(r1cs)?);
         let r1cs = R1CSFile::new(reader)?.into();
         Ok(Self {
             wtns,


### PR DESCRIPTION
This PR enhances the speed of reading R1CS files by introducing `BufReader`. Frequent reading of `u32` data significantly slows down the reading of R1CS files, and `BufReader` optimizes this by buffering large blocks of data, reducing the number of direct read calls to the disk. This change reduced the reading time of a file with 5 million R1CS constraints from 28 seconds to 1.2 seconds, significantly boosting efficiency.

