### PR TITLE
Publicly expose Wasm type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides bindings to Circom's R1CS, for Groth16 Proof and Witness generation in Rust.
 mod witness;
-pub use witness::WitnessCalculator;
+pub use witness::{Wasm, WitnessCalculator};
 
 pub mod circom;
 pub use circom::{CircomBuilder, CircomCircuit, CircomConfig, CircomReduction};

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -5,7 +5,8 @@ mod memory;
 pub(super) use memory::SafeMemory;
 
 mod circom;
-pub(super) use circom::{CircomBase, Wasm};
+pub use circom::Wasm;
+pub(super) use circom::CircomBase;
 
 #[cfg(feature = "circom-2")]
 pub(super) use circom::Circom2;

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -5,8 +5,8 @@ mod memory;
 pub(super) use memory::SafeMemory;
 
 mod circom;
-pub use circom::Wasm;
 pub(super) use circom::CircomBase;
+pub use circom::Wasm;
 
 #[cfg(feature = "circom-2")]
 pub(super) use circom::Circom2;


### PR DESCRIPTION
In PR #64, one of the changes introduced was to allow constructing a `WitnessGenerator` from an existing `Wasm` instance (see change [here](https://github.com/arkworks-rs/circom-compat/pull/64/files#diff-3e6d923e61052f4370a458846ecbbaa7ddfb0900336f16ba83936e3f68a4e826R45)). I accidentally forgot to publicly expose the `Wasm` type :man_facepalming:, so this is a follow-up PR to do just that. Sorry about the slip-up.

Here is an [example integration](https://github.com/l-adic/arkworks-demo/blob/main/src/main.rs#L56-L73) which proves that this method works.